### PR TITLE
Fix the `afterSync` task in sample

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: org.jetbrains.gradle.ext.IdeaExtPlugin
 task('testIdea') {
     doLast {
         println('I\'m being run!')
-        file("${buildDir}/testIdea.log") << 'Task was run' 
+        file("${projectDir}/testIdea.log") << 'Task was run' 
     }
 }
 


### PR DESCRIPTION
Unfortunately, because `Build` tool window does not get open, task failure stays invisible.
As a partial workaround, please run `gradlew <yourTask>` from command line, to check if it works.
Also, running some  gradle task from IDE -> clean task output  -> run import will show the `afterSync` task output.